### PR TITLE
Revert header to old version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,10 +12,6 @@
 <body>
     <div class="container">
         <header>
-            <div class="header-content">
-                <h1>Course Materials Assistant</h1>
-                <p class="subtitle">Ask questions about courses, instructors, and content</p>
-            </div>
             <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
                 <span class="theme-icon sun-icon">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -77,35 +77,13 @@ body {
 /* Header */
 header {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
-    padding: 1.5rem 2rem;
+    padding: 1rem 2rem;
     background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
     flex-shrink: 0;
 }
 
-.header-content {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin: 0;
-}
 
 /* Theme Toggle Button */
 .theme-toggle {
@@ -899,18 +877,8 @@ details[open] .suggested-header::before {
     }
     
     header {
-        padding: 1rem;
-        flex-direction: column;
-        gap: 1rem;
-        text-align: center;
-    }
-    
-    .header-content {
-        align-items: center;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
+        padding: 0.75rem 1rem;
+        justify-content: flex-end;
     }
     
     .theme-toggle {
@@ -1006,42 +974,6 @@ details[open] .suggested-header::before {
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }
 
-/* Theme Toggle Button */
-.theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 50px;
-    height: 50px;
-    border-radius: 50%;
-    border: 2px solid var(--border-color);
-    background: var(--surface);
-    color: var(--text-primary);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.2rem;
-    transition: all 0.3s ease;
-    z-index: 1000;
-    box-shadow: var(--shadow);
-}
-
-.theme-toggle:hover {
-    background: var(--surface-hover);
-    border-color: var(--primary-color);
-    transform: scale(1.1);
-    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
-}
-
-.theme-toggle:focus {
-    outline: none;
-    box-shadow: 0 0 0 3px var(--focus-ring), var(--shadow);
-}
-
-.theme-toggle:active {
-    transform: scale(0.95);
-}
 
 /* Add transitions to all elements that change with theme */
 *, *::before, *::after {


### PR DESCRIPTION
This PR addresses issue #2 by reverting the header to a minimal version.

## Changes
- Removed "Course Materials Assistant" title and subtitle
- Removed horizontal border below header
- Preserved theme toggle functionality
- Updated CSS to position theme toggle on the right
- Cleaned up unused CSS rules
- Fixed mobile responsive styles

Fixes #2

Generated with [Claude Code](https://claude.ai/code)